### PR TITLE
ホーム画面：TodoItemViewの完了ボタンがわかりにくい

### DIFF
--- a/TodoNote/TodoNote/Resource/Colors.xcassets/Amber300.colorset/Contents.json
+++ b/TodoNote/TodoNote/Resource/Colors.xcassets/Amber300.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.310",
+          "green" : "0.835",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TodoNote/TodoNote/Resource/Colors.xcassets/LightGreen300.colorset/Contents.json
+++ b/TodoNote/TodoNote/Resource/Colors.xcassets/LightGreen300.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.506",
+          "green" : "0.835",
+          "red" : "0.682"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TodoNote/TodoNote/Resource/Colors.xcassets/Red300.colorset/Contents.json
+++ b/TodoNote/TodoNote/Resource/Colors.xcassets/Red300.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.451",
+          "green" : "0.451",
+          "red" : "0.898"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TodoNote/TodoNote/Screen/Common/View/TodoItemView.swift
+++ b/TodoNote/TodoNote/Screen/Common/View/TodoItemView.swift
@@ -17,13 +17,20 @@ struct TodoItemView: View {
     var body: some View {
         HStack(spacing: 0) {
             Button(action: doneAction) {
-                Circle()
-                    .fill(computeFillColor())
-                    .frame(width: 32, height: 32)
-                    .overlay(
-                        Circle()
-                            .stroke(computeStrokeColor())
-                    )
+                ZStack {
+                    Circle()
+                        .fill(computeFillColor())
+                        .overlay(
+                            Circle()
+                                .stroke(computeStrokeColor())
+                        )
+                    Image(systemName: "checkmark")
+                        .resizable()
+                        .frame(width: 12, height: 12)
+                        .scaledToFit()
+                        .foregroundColor(Color.white)
+                }
+                .frame(width: 32, height: 32)
             }
             .buttonStyle(.plain)
             .padding(.trailing, 12)
@@ -58,11 +65,11 @@ struct TodoItemView: View {
         let todoDate = Calendar.current.startOfDay(for: item.datetime)
 
         if todoDate < today {
-            return R.color.red50.color
+            return R.color.red300.color
         } else if todoDate == today {
-            return R.color.amber50.color
+            return R.color.amber300.color
         } else {
-            return R.color.lightGreen50.color
+            return R.color.lightGreen300.color
         }
     }
 

--- a/TodoNote/TodoNote/Screen/Common/View/TodoItemView.swift
+++ b/TodoNote/TodoNote/Screen/Common/View/TodoItemView.swift
@@ -15,48 +15,41 @@ struct TodoItemView: View {
     let editAction: () -> Void
 
     var body: some View {
-        HStack(spacing: 0) {
-            Button(action: doneAction) {
-                ZStack {
-                    Circle()
-                        .fill(computeFillColor())
-                        .overlay(
-                            Circle()
-                                .stroke(computeStrokeColor())
-                        )
-                    Image(systemName: "checkmark")
-                        .resizable()
-                        .frame(width: 12, height: 12)
-                        .scaledToFit()
-                        .foregroundColor(Color.white)
+        Button(action: editAction) {
+            HStack(spacing: 0) {
+                Button(action: doneAction) {
+                    ZStack {
+                        Circle()
+                            .fill(computeFillColor())
+                            .overlay(
+                                Circle()
+                                    .stroke(computeStrokeColor())
+                            )
+                        Image(systemName: "checkmark")
+                            .resizable()
+                            .frame(width: 12, height: 12)
+                            .scaledToFit()
+                            .foregroundColor(Color.white)
+                    }
+                    .frame(width: 32, height: 32)
                 }
-                .frame(width: 32, height: 32)
-            }
-            .buttonStyle(.plain)
-            .padding(.trailing, 12)
-            .padding(.vertical, 4)
+                .buttonStyle(.plain)
+                .padding(.trailing, 12)
+                .padding(.vertical, 4)
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(item.title)
-                    .font(.system(size: 16, weight: .bold))
-                    .foregroundColor(Color.black)
-                if let desc = item.description, !desc.isEmpty {
-                    Text(desc)
-                        .font(.system(size: 14, weight: .regular))
-                        .foregroundColor(R.color.grey700.color)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.title)
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(Color.black)
+                    if let desc = item.description, !desc.isEmpty {
+                        Text(desc)
+                            .font(.system(size: 14, weight: .regular))
+                            .foregroundColor(R.color.grey700.color)
+                    }
                 }
-            }
 
-            Spacer(minLength: 0)
-
-            Button(action: editAction) {
-                Image(systemName: "pencil")
-                    .resizable()
-                    .frame(width: 16, height: 16)
-                    .scaledToFit()
-                    .foregroundColor(R.color.accentColor.color)
+                Spacer(minLength: 0)
             }
-            .buttonStyle(.plain)
         }
     }
 

--- a/TodoNote/TodoNote/Screen/Common/View/TodoItemView.swift
+++ b/TodoNote/TodoNote/Screen/Common/View/TodoItemView.swift
@@ -30,6 +30,7 @@ struct TodoItemView: View {
                             .frame(width: 12, height: 12)
                             .scaledToFit()
                             .foregroundColor(Color.white)
+                            .opacity(0.4)
                     }
                     .frame(width: 32, height: 32)
                 }


### PR DESCRIPTION
## 関連するIssue

<!-- ここにIssueのURLを追加する
* #66
-->

* https://github.com/CH3COOH/todonote-ios/issues/29

## 関連するPull Request

<!-- ここにPRのURLを追加する
* #66
-->

* なし

## やったこと

<!--
* [ ] これからやることを書く
-->

* [x] 編集ボタンの廃止 (アイテムをタップしたときに編集画面画面へ遷移させる)
* [x] 丸View にチェックマークをうっすら表示させる 

## このPull Requestではやっていないこと

<!--
* このPull Requestでやっていないことを書く
-->

* なし

## スクショ

<!--
画面のデザイン変更の場合スクリーンショットを貼ってください。UIに影響しない処理・動作の変更の場合には不要です。
-->

| before | after | カンプ |
|:----|:----|:----|
| <img src="https://github.com/CH3COOH/todonote-ios/assets/137952/dcffa448-f736-4cdc-b7fc-1d54ede72cbc" width="320px" /> | <img src="https://github.com/CH3COOH/todonote-ios/assets/137952/3ce3d29b-1ddd-43d3-8bca-171a5de0509e" width="320px" /> | <img src="" width="320px" /> |
